### PR TITLE
bump traefik version

### DIFF
--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -6,7 +6,7 @@ POSTGRESQL_IMAGE=registry1.dso.mil/ironbank/opensource/postgres/postgresql12:12.
 MINIO_IMAGE=registry1.dso.mil/ironbank/opensource/minio/minio:RELEASE.2022-01-28T02-28-16Z
 JUPYTERHUB_IMAGE=registry1.dso.mil/ironbank/opensource/metrostar/jupyterhub:jupyterhub_v10
 KEYCLOAK_IMAGE=registry1.dso.mil/ironbank/opensource/keycloak/keycloak:16.1.1
-TRAEFIK_IMAGE=registry1.dso.mil/ironbank/opensource/traefik/traefik:v2.9.9
+TRAEFIK_IMAGE=registry1.dso.mil/ironbank/opensource/traefik/traefik:v3.0.4
 MONGODB_IMAGE=registry1.dso.mil/ironbank/opensource/mongodb/mongodb:6.0.5
 CUDA_IMAGE=registry1.dso.mil/ironbank/opensource/metrostar/pytorch:cuda_v3
 

--- a/docker-compose/traefik/traefik.yml
+++ b/docker-compose/traefik/traefik.yml
@@ -20,7 +20,7 @@ entrypoints:
 
 api:
   dashboard: false
-  insecure: true
+  insecure: false
 
 ping: true
 


### PR DESCRIPTION
also disabled "insecure" setting for api, just in case. Didn't seem to have any impact on functionality