### PR TITLE
traefik access logs now persisted in svc directory

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -91,6 +91,7 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
       - "./traefik/traefik_dynamic.yml:/etc/traefik/traefik_dynamic.yml"
       - "./traefik/traefik.yml:/etc/traefik/traefik.yml"
+      - "./traefik/access_logs/:/logs/"
     env_file:
       - ./.env
       - ./.env.secrets

--- a/docker-compose/traefik/traefik.yml
+++ b/docker-compose/traefik/traefik.yml
@@ -24,6 +24,11 @@ api:
 
 ping: true
 
+accessLog:
+  filepath: "/logs/access.json"
+  format: json
+  bufferingSize: 10
+
 #Uncomment below for increased logging
 # log:
 #   level: DEBUG


### PR DESCRIPTION
No changes needed for testing. Just deploy, access a few services, and check `docker-compose/traefik/access_logs/access.json`
Redeploy, and the logs should still be there