### PR TITLE
Opal 966

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,19 +54,13 @@ https://opal.127.0.0.1.nip.io/hub/
 
 NOTE: If the links above do not resolve then you will need to modify your hosts file and have minio.127.0.0.1.nip.io, jupyterhub.127.0.0.1.nip.io, keycloak.127.0.0.1.nip.io resolve to localhost.
 
-The user login for jupyterhub:
-
-```
-user: opaluser
-pass: opalpassword
-```
-
-The admin user credentials for keycloak:
+The user login for jupyterhub and keycloak is:
 
 ```
 user: admin
 pass: opal
 ```
+
 
 #### Adding other users to the deployment
 

--- a/docker-compose/keycloak/keycloak_script.sh
+++ b/docker-compose/keycloak/keycloak_script.sh
@@ -133,7 +133,7 @@ JUPYTERHUB_STAFF_GROUP_ID=$(./kcadm.sh get groups -r master | grep jupyterhub_st
 # Adds policy=readwrite to staff_group
 
 ./kcadm.sh update groups/$JUPYTERHUB_STAFF_GROUP_ID -s 'attributes.policy=["readwrite"]' -r master
-./kcadm.sh update groups/$JUPYTERHUB_ADMINS_GROUP_ID -s 'attributes.policy=["consolewrite"]' -r master
+./kcadm.sh update groups/$JUPYTERHUB_ADMINS_GROUP_ID -s 'attributes.policy=["consoleAdmin"]' -r master
 
 # Adds policy=consoleAdmin to the 'admin' user in keycloak, allowing login to minio
 #ADMIN_USER_ID=$(./kcadm.sh get users -r master -q username=admin | grep id | awk -F'"' '{print $4}')

--- a/docker-compose/keycloak/keycloak_script.sh
+++ b/docker-compose/keycloak/keycloak_script.sh
@@ -109,10 +109,8 @@ echo "creating minio test user"
 ./kcadm.sh create users \
             -r master\
             -s username=$MINIO_TEST_USER \
-            -s enabled=true \
             -s "attributes.policy=consoleAdmin"
-
-echo "setting minio test user's password"
+#echo "setting minio test user's password"
 ./kcadm.sh set-password \
             -r master \
             --username $MINIO_TEST_USER \
@@ -132,8 +130,10 @@ JUPYTERHUB_ADMINS_GROUP_ID=$(./kcadm.sh get groups -r master | grep jupyterhub_a
 JUPYTERHUB_STAFF_GROUP_ID=$(./kcadm.sh get groups -r master | grep jupyterhub_staff -B 1 | grep id | awk -F'"' '{print $4}')
 ./kcadm.sh update users/$MINIO_ADMIN_ID/groups/$JUPYTERHUB_STAFF_GROUP_ID -r master -s realm=master -s userId=$MINIO_ADMIN_ID -s groupId=$JUPYTERHUB_STAFF_GROUP_ID -n
 
-# Adds policy=consoleAdmin to the 'admin' user in keycloak, allowing login to minio
-ADMIN_USER_ID=$(./kcadm.sh get users -r master -q username=admin | grep id | awk -F'"' '{print $4}')
+# Adds policy=readwrite to staff_group
+./kcadm.sh update groups/$JUPYTERHUB_STAFF_GROUP_ID -s 'attributes.policy=["readwrite"]' -r master
 
+# Adds policy=consoleAdmin to the 'admin' user in keycloak, allowing login to minio
+#ADMIN_USER_ID=$(./kcadm.sh get users -r master -q username=admin | grep id | awk -F'"' '{print $4}')
 ./kcadm.sh update users/$ADMIN_USER_ID -r master -s 'attributes.policy=consoleAdmin'
 echo "Done initializing keycloak"

--- a/docker-compose/keycloak/keycloak_script.sh
+++ b/docker-compose/keycloak/keycloak_script.sh
@@ -109,7 +109,7 @@ echo "creating minio test user"
 ./kcadm.sh create users \
             -r master\
             -s username=$MINIO_TEST_USER \
-            -s "attributes.policy=consoleAdmin"
+            -s enabled=true \
 #echo "setting minio test user's password"
 ./kcadm.sh set-password \
             -r master \
@@ -131,9 +131,11 @@ JUPYTERHUB_STAFF_GROUP_ID=$(./kcadm.sh get groups -r master | grep jupyterhub_st
 ./kcadm.sh update users/$MINIO_ADMIN_ID/groups/$JUPYTERHUB_STAFF_GROUP_ID -r master -s realm=master -s userId=$MINIO_ADMIN_ID -s groupId=$JUPYTERHUB_STAFF_GROUP_ID -n
 
 # Adds policy=readwrite to staff_group
+
 ./kcadm.sh update groups/$JUPYTERHUB_STAFF_GROUP_ID -s 'attributes.policy=["readwrite"]' -r master
+./kcadm.sh update groups/$JUPYTERHUB_ADMINS_GROUP_ID -s 'attributes.policy=["consolewrite"]' -r master
 
 # Adds policy=consoleAdmin to the 'admin' user in keycloak, allowing login to minio
 #ADMIN_USER_ID=$(./kcadm.sh get users -r master -q username=admin | grep id | awk -F'"' '{print $4}')
-./kcadm.sh update users/$ADMIN_USER_ID -r master -s 'attributes.policy=consoleAdmin'
+#./kcadm.sh update users/$ADMIN_USER_ID -r master -s 'attributes.policy=consoleAdmin'
 echo "Done initializing keycloak"


### PR DESCRIPTION
This PR is used to buy pass setting up the group attributes in Keycloak making it easier to deploy.  Simple spin up a local instance of Opal-ops and login with the admin user in keycloak.  Make sure the user is added to both groups, and the jupyterhub_staff group has the attribute readwrite.  You can also log into jupyterhub and check that everything spins up properly.