### PR TITLE
Updated opal's default credentials on keycloak

### DIFF
--- a/docker-compose/keycloak/keycloak_script.sh
+++ b/docker-compose/keycloak/keycloak_script.sh
@@ -124,17 +124,39 @@ echo "creating staff groups"
 ./kcadm.sh create groups -r master -s name=jupyterhub_staff
 echo "created jupyterhub_admins and jupyterhub_staff groups"
 
-# Add 'policy=readwrite' attribute to jupyterhub_staff group
+# Add 'policy=consoleAdmin' attribute to jupyterhub_staff group
 JUPYTERHUB_STAFF_GROUP_ID=$(./kcadm.sh get groups -r master | grep jupyterhub_staff -B 1 | grep id | awk -F'"' '{print $4}')
-./kcadm.sh update groups/$JUPYTERHUB_STAFF_GROUP_ID -r master -s 'attributes.policy=readwrite'
-echo "Set policy=readwrite on jupyterhub_staff group"
+./kcadm.sh update groups/$JUPYTERHUB_STAFF_GROUP_ID -r master -f - <<EOF
+{
+  "name": "jupyterhub_staff",
+  "attributes": {
+    "policy": ["consoleAdmin"]
+  }
+}
+EOF
+
+echo "Set policy=consoleAdmin on jupyterhub_staff group"
+
+# Add 'policy=consoleAdmin' attribute to jupyterhub_admin group
+JUPYTERHUB_ADMINS_GROUP_ID=$(./kcadm.sh get groups -r master | grep jupyterhub_admins -B 1 | grep id | awk -F'"' '{print $4}')
+./kcadm.sh update groups/$JUPYTERHUB_ADMINS_GROUP_ID -r master -f - <<EOF
+{
+  "name": "jupyterhub_admins",
+  "attributes": {
+    "policy": ["consoleAdmin"]
+  }
+}
+EOF
+
+echo "Set policy=consoleAdmin on jupyterhub_admin group"
 
 # Adds admin user to jupyterhub_admins and jupyterhub_staff groups
 MINIO_ADMIN_ID=$(./kcadm.sh get users -r master -q username=$MINIO_TEST_USER | grep id | awk -F'"' '{print $4}')
-JUPYTERHUB_ADMINS_GROUP_ID=$(./kcadm.sh get groups -r master | grep jupyterhub_admins -B 1 | grep id | awk -F'"' '{print $4}')
+
+# JUPYTERHUB_ADMINS_GROUP_ID=$(./kcadm.sh get groups -r master | grep jupyterhub_admins -B 1 | grep id | awk -F'"' '{print $4}')
 ./kcadm.sh update users/$MINIO_ADMIN_ID/groups/$JUPYTERHUB_ADMINS_GROUP_ID -r master -s realm=master -s userId=$MINIO_ADMIN_ID -s groupId=$JUPYTERHUB_ADMINS_GROUP_ID -n
 
-JUPYTERHUB_STAFF_GROUP_ID=$(./kcadm.sh get groups -r master | grep jupyterhub_staff -B 1 | grep id | awk -F'"' '{print $4}')
+# JUPYTERHUB_STAFF_GROUP_ID=$(./kcadm.sh get groups -r master | grep jupyterhub_staff -B 1 | grep id | awk -F'"' '{print $4}')
 ./kcadm.sh update users/$MINIO_ADMIN_ID/groups/$JUPYTERHUB_STAFF_GROUP_ID -r master -s realm=master -s userId=$MINIO_ADMIN_ID -s groupId=$JUPYTERHUB_STAFF_GROUP_ID -n
 
 # Adds policy=consoleAdmin to the 'admin' user in keycloak, allowing login to minio

--- a/docker-compose/keycloak/keycloak_script.sh
+++ b/docker-compose/keycloak/keycloak_script.sh
@@ -124,6 +124,11 @@ echo "creating staff groups"
 ./kcadm.sh create groups -r master -s name=jupyterhub_staff
 echo "created jupyterhub_admins and jupyterhub_staff groups"
 
+# Add 'policy=readwrite' attribute to jupyterhub_staff group
+JUPYTERHUB_STAFF_GROUP_ID=$(./kcadm.sh get groups -r master | grep jupyterhub_staff -B 1 | grep id | awk -F'"' '{print $4}')
+./kcadm.sh update groups/$JUPYTERHUB_STAFF_GROUP_ID -r master -s 'attributes.policy=readwrite'
+echo "Set policy=readwrite on jupyterhub_staff group"
+
 # Adds admin user to jupyterhub_admins and jupyterhub_staff groups
 MINIO_ADMIN_ID=$(./kcadm.sh get users -r master -q username=$MINIO_TEST_USER | grep id | awk -F'"' '{print $4}')
 JUPYTERHUB_ADMINS_GROUP_ID=$(./kcadm.sh get groups -r master | grep jupyterhub_admins -B 1 | grep id | awk -F'"' '{print $4}')

--- a/docker-compose/keycloak/keycloak_script.sh
+++ b/docker-compose/keycloak/keycloak_script.sh
@@ -153,10 +153,8 @@ echo "Set policy=consoleAdmin on jupyterhub_admin group"
 # Adds admin user to jupyterhub_admins and jupyterhub_staff groups
 MINIO_ADMIN_ID=$(./kcadm.sh get users -r master -q username=$MINIO_TEST_USER | grep id | awk -F'"' '{print $4}')
 
-# JUPYTERHUB_ADMINS_GROUP_ID=$(./kcadm.sh get groups -r master | grep jupyterhub_admins -B 1 | grep id | awk -F'"' '{print $4}')
+# Adds minio test user to jupyterhub_admins and jupyterhub_staff groups
 ./kcadm.sh update users/$MINIO_ADMIN_ID/groups/$JUPYTERHUB_ADMINS_GROUP_ID -r master -s realm=master -s userId=$MINIO_ADMIN_ID -s groupId=$JUPYTERHUB_ADMINS_GROUP_ID -n
-
-# JUPYTERHUB_STAFF_GROUP_ID=$(./kcadm.sh get groups -r master | grep jupyterhub_staff -B 1 | grep id | awk -F'"' '{print $4}')
 ./kcadm.sh update users/$MINIO_ADMIN_ID/groups/$JUPYTERHUB_STAFF_GROUP_ID -r master -s realm=master -s userId=$MINIO_ADMIN_ID -s groupId=$JUPYTERHUB_STAFF_GROUP_ID -n
 
 # Adds policy=consoleAdmin to the 'admin' user in keycloak, allowing login to minio

--- a/kubernetes/base/extra_resources/keycloak_script.sh
+++ b/kubernetes/base/extra_resources/keycloak_script.sh
@@ -90,6 +90,11 @@ echo "creating staff groups"
 ./kcadm.sh create groups -r master -s name=jupyterhub_staff
 echo "created jupyterhub_admins and jupyterhub_staff groups"
 
+# Add 'policy=readwrite' attribute to jupyterhub_staff group
+JUPYTERHUB_STAFF_GROUP_ID=$(./kcadm.sh get groups -r master | grep jupyterhub_staff -B 1 | grep id | awk -F'"' '{print $4}')
+./kcadm.sh update groups/$JUPYTERHUB_STAFF_GROUP_ID -r master -s 'attributes.policy=readwrite'
+echo "Set policy=readwrite on jupyterhub_staff group"
+
 # Adds admin user to jupyterhub_admins and jupyterhub_staff groups
 MINIO_ADMIN_ID=$(./kcadm.sh get users -r master -q username=$MINIO_TEST_USER | grep id | awk -F'"' '{print $4}')
 JUPYTERHUB_ADMINS_GROUP_ID=$(./kcadm.sh get groups -r master | grep jupyterhub_admins -B 1 | grep id | awk -F'"' '{print $4}')


### PR DESCRIPTION
Updated keycloak script to add read/write policy and add default user to default group automatically. This removes the need for manual configuration for each deployment.